### PR TITLE
Harmonize kwargs, client check

### DIFF
--- a/analysisstore/ignition.py
+++ b/analysisstore/ignition.py
@@ -37,12 +37,12 @@ def start_server(config=None):
         parser = argparse.ArgumentParser()
         parser.add_argument('--database', dest='database', type=str,
                             help='name of database to use')
-        parser.add_argument('--mongo-uri',
+        parser.add_argument('--mongo_uri',
                              dest='mongo_uri', type=str,
                             help='uri of Mongo DB')
         parser.add_argument('--timezone', dest='timezone', type=str,
                             help='Local timezone')
-        parser.add_argument('--service-port', dest='service_port', type=int,
+        parser.add_argument('--service_port', dest='service_port', type=int,
                             help='port listen to for clients')
         parser.add_argument('--log-file_prefix', dest='log_file_prefix', type=str,
                             help='Log file name that tornado logs are dumped')

--- a/analysisstore/server/astore.py
+++ b/analysisstore/server/astore.py
@@ -1,7 +1,9 @@
 from pymongo import MongoClient, DESCENDING
+import pymongo
 import jsonschema
 import json
 import six
+from .utils import AnalysisstoreException
 
 
 class AStore:
@@ -16,7 +18,11 @@ class AStore:
             uri in string format, and database
         """
         if not testing:
-            self.client = MongoClient(config["uri"])
+            try:
+                self.client = MongoClient(config["uri"])
+                self.client.server_info()
+            except (pymongo.errors.ConnectionFailure, pymongo.errors.ServerSelectionTimeoutError):
+                raise AnalysisstoreException("Unable to connect to MongoDB server...")
         else:
             import mongomock
 

--- a/analysisstore/server/astore.py
+++ b/analysisstore/server/astore.py
@@ -20,6 +20,7 @@ class AStore:
         if not testing:
             try:
                 self.client = MongoClient(config["uri"])
+                # Proactively check that connection to server is working.
                 self.client.server_info()
             except (pymongo.errors.ConnectionFailure, pymongo.errors.ServerSelectionTimeoutError):
                 raise AnalysisstoreException("Unable to connect to MongoDB server...")

--- a/analysisstore/server/utils.py
+++ b/analysisstore/server/utils.py
@@ -5,6 +5,9 @@ from pkg_resources import resource_filename as rs_fn
 import ujson
 import pymongo.cursor
 
+class AnalysisstoreException(Exception):
+    pass
+
 
 SCHEMA_PATH = 'schemas'
 SCHEMA_NAMES = {'analysis_header': 'analysis_header.json',
@@ -73,4 +76,4 @@ def return2client(handler, payload):
             except StopIteration:
                 break
         handler.write(']')
-    handler.finish()                                                                                                                                                                 
+    handler.finish()

--- a/analysisstore/test/testing.py
+++ b/analysisstore/test/testing.py
@@ -19,11 +19,11 @@ TESTING_CONFIG = dict(host='localhost', port=7601,
 def astore_setup():
     f = os.path.dirname(os.path.realpath(__file__))
     proc = Popen(["python", "../startup.py",
-                                 "--mongo-uri",
+                                 "--mongo_uri",
                                  str(TESTING_CONFIG['mongouri']),
                                  "--database", TESTING_CONFIG['database'],
                                  "--timezone", TESTING_CONFIG['timezone'],
-                                 "--service-port",
+                                 "--service_port",
                                  str(TESTING_CONFIG['serviceport'])], cwd=f)
     ttime.sleep(1.3) # make sure the process is started
     return proc


### PR DESCRIPTION
- Harmonize kwargs with amostra and conftrak so they are consistent. This will be useful for the ansible role to install and run them as services in particular.
- Standardize on `server_info()` as the function to call on the Mongo client as a way to check that the client is alive.