### PR TITLE
Update version requirement

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         dependencies: ["pip", "conda"]
       fail-fast: false
 
@@ -53,7 +53,8 @@ jobs:
         if: matrix.dependencies == 'conda'
         run: |
           set -vxeo pipefail
-          conda install -y -c conda-forge six mongoquery doct jsonschema mock mongomock pymongo pytest pyyaml requests tornado ujson
+          conda install -y -c conda-forge six mongoquery doct jsonschema mock pymongo pytest pyyaml requests tornado ujson
+          pip install mongomock
 
       - name: Install the package
         run: |

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,10 @@ import versioneer
 import os
 import sys
 
-# NOTE: This file must remain Python 2 compatible for the foreseeable future,
-# to ensure that we error out properly for people with outdated setuptools
-# and/or pip.
-min_version = (3, 6)
+min_version = (3, 8)
 if sys.version_info < min_version:
     error = """
-mxtools does not support Python {0}.{1}.
+analysisstore does not support Python {0}.{1}.
 Python {2}.{3} and above is required. Check your Python version like so:
 
 python3 --version
@@ -61,5 +58,10 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Development Status :: 3 - Alpha",
         'Programming Language :: Python :: 3',
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )


### PR DESCRIPTION
- The default `mongomock` library is now 4.2.0.post1, which now limits compatibility to Python 3.8 and above
- Due to the lack of up-to-date `mongomock` packages for conda, for the conda tests, use pip to install `mongomock`